### PR TITLE
Call check_pending_prs after sync to auto-create PRs

### DIFF
--- a/agenttree/agents_repo.py
+++ b/agenttree/agents_repo.py
@@ -101,8 +101,9 @@ def sync_agents_repo(
                 print(f"Warning: Failed to pull .agenttrees repo: {result.stderr}")
                 return False
 
-        # If pull-only, we're done
+        # If pull-only, check for pending PRs and we're done
         if pull_only:
+            check_pending_prs(agents_dir)
             return True
 
         # Push changes (local commits + any we just made)
@@ -120,6 +121,9 @@ def sync_agents_repo(
             else:
                 print(f"Warning: Failed to push changes: {push_result.stderr}")
             return False
+
+        # After successful sync, check for issues needing PRs
+        check_pending_prs(agents_dir)
 
         return True
 


### PR DESCRIPTION
The check_pending_prs function was defined but never called. Now it runs after successful sync operations (both pull-only and full push) to create PRs for issues at implementation_review stage that don't have PRs yet.

This handles the case where agents in containers can't push directly - the host picks up the work during sync.