### PR TITLE
Remove dashboard tab, redirect / to kanban, use white bg for markdown

### DIFF
--- a/agenttree/web/app.py
+++ b/agenttree/web/app.py
@@ -245,17 +245,10 @@ def get_kanban_board() -> KanbanBoard:
     return KanbanBoard(stages=stages, total_issues=len(issues))
 
 
-@app.get("/", response_class=HTMLResponse)
-async def dashboard(
-    request: Request,
-    user: Optional[str] = Depends(get_current_user)
-) -> HTMLResponse:
-    """Main dashboard page."""
-    agents = agent_manager.get_all_agents()
-    return templates.TemplateResponse(
-        "dashboard.html",
-        {"request": request, "agents": agents, "user": user, "active_page": "dashboard"}
-    )
+@app.get("/")
+async def root() -> RedirectResponse:
+    """Redirect root to kanban board."""
+    return RedirectResponse(url="/kanban", status_code=302)
 
 
 @app.get("/kanban", response_class=HTMLResponse)

--- a/agenttree/web/templates/partials/header.html
+++ b/agenttree/web/templates/partials/header.html
@@ -2,7 +2,6 @@
     <div class="header-row">
         <h1>🤖🌳 AgentTree</h1>
         <nav class="tabs">
-            <a href="/" class="tab {{ 'active' if active_page == 'dashboard' else '' }}">Dashboard</a>
             <a href="/kanban" class="tab {{ 'active' if active_page == 'kanban' else '' }}">Kanban</a>
             <a href="/flow" class="tab {{ 'active' if active_page == 'flow' else '' }}">Flow</a>
         </nav>

--- a/agenttree/web/templates/partials/header_styles.html
+++ b/agenttree/web/templates/partials/header_styles.html
@@ -227,7 +227,7 @@ header h1 {
 
 /* Markdown rendering */
 .markdown-content {
-    background: var(--bg-card-alt);
+    background: var(--bg-card);
     border: 1px solid var(--border-light);
     border-radius: 6px;
     padding: 20px;
@@ -496,6 +496,8 @@ header h1 {
 
 .file-content {
     padding: 15px;
+    background: var(--bg-card);
+    border-radius: 6px;
 }
 
 .empty-state {


### PR DESCRIPTION
## Summary
- Remove Dashboard tab from navigation header (Kanban and Flow are sufficient)
- Redirect root "/" to /kanban for simpler navigation
- Update markdown content and file-content areas to use white background (--bg-card)

## Test plan
- [ ] Visit / - should redirect to /kanban
- [ ] Check navigation - only Kanban and Flow tabs
- [ ] View issue detail - markdown content should have white background

🤖 Generated with [Claude Code](https://claude.com/claude-code)