### PR TITLE
[Issue 076] Init script should batch-check all dependencies upfront

### DIFF
--- a/agenttree/dependencies.py
+++ b/agenttree/dependencies.py
@@ -1,0 +1,269 @@
+"""Dependency checking module for AgentTree init.
+
+This module provides batch checking of all required dependencies at init time,
+reporting all issues at once rather than failing on the first problem.
+"""
+
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from rich.console import Console
+
+from agenttree.container import ContainerRuntime
+
+
+@dataclass
+class DependencyResult:
+    """Result of a single dependency check.
+
+    Attributes:
+        name: Identifier for the dependency check
+        passed: Whether the check passed
+        description: Human-readable description of the result
+        fix_instructions: Instructions for fixing the issue (if failed)
+        required: If True, failure blocks init. If False, it's just a warning.
+    """
+
+    name: str
+    passed: bool
+    description: str
+    fix_instructions: Optional[str] = None
+    required: bool = True
+
+
+def check_git_repo(path: Path) -> DependencyResult:
+    """Check if the given path is inside a git repository.
+
+    Args:
+        path: Directory path to check
+
+    Returns:
+        DependencyResult indicating whether .git exists
+    """
+    git_dir = path / ".git"
+
+    if git_dir.exists():
+        return DependencyResult(
+            name="git_repo",
+            passed=True,
+            description="Git repository detected",
+        )
+    else:
+        return DependencyResult(
+            name="git_repo",
+            passed=False,
+            description="Not a git repository",
+            fix_instructions="Run `git init` to create a repository, or navigate to an existing git repo",
+        )
+
+
+def check_gh_installed() -> DependencyResult:
+    """Check if the GitHub CLI (gh) is installed.
+
+    Returns:
+        DependencyResult indicating whether gh is found in PATH
+    """
+    gh_path = shutil.which("gh")
+
+    if gh_path:
+        return DependencyResult(
+            name="gh_installed",
+            passed=True,
+            description="GitHub CLI installed",
+        )
+    else:
+        return DependencyResult(
+            name="gh_installed",
+            passed=False,
+            description="GitHub CLI not installed",
+            fix_instructions=(
+                "Install from https://cli.github.com/\n"
+                "  macOS:   brew install gh\n"
+                "  Linux:   See https://github.com/cli/cli#installation\n"
+                "  Windows: See https://github.com/cli/cli#installation"
+            ),
+        )
+
+
+def check_gh_authenticated() -> DependencyResult:
+    """Check if the GitHub CLI is authenticated.
+
+    Uses a 5-second timeout to avoid hanging on network issues.
+
+    Returns:
+        DependencyResult indicating whether gh auth status succeeds
+    """
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "status"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+
+        if result.returncode == 0:
+            return DependencyResult(
+                name="gh_authenticated",
+                passed=True,
+                description="GitHub CLI authenticated",
+            )
+        else:
+            return DependencyResult(
+                name="gh_authenticated",
+                passed=False,
+                description="GitHub CLI not authenticated",
+                fix_instructions=(
+                    "Run `gh auth login` to authenticate.\n"
+                    "This will open your browser to log in to GitHub."
+                ),
+            )
+    except subprocess.TimeoutExpired:
+        return DependencyResult(
+            name="gh_authenticated",
+            passed=False,
+            description="GitHub CLI auth check timed out (network issue?)",
+            fix_instructions="Check your network connection and try `gh auth status` manually",
+        )
+    except FileNotFoundError:
+        return DependencyResult(
+            name="gh_authenticated",
+            passed=False,
+            description="GitHub CLI not found (cannot check auth)",
+            fix_instructions="Install gh CLI first",
+        )
+    except Exception as e:
+        return DependencyResult(
+            name="gh_authenticated",
+            passed=False,
+            description=f"GitHub CLI auth check failed: {e}",
+            fix_instructions="Try running `gh auth status` manually to diagnose",
+        )
+
+
+def check_container_runtime() -> DependencyResult:
+    """Check if a container runtime is available.
+
+    This is a non-blocking check (required=False) since agents can still
+    work without containers in some scenarios.
+
+    Returns:
+        DependencyResult with required=False (warning only)
+    """
+    runtime = ContainerRuntime()
+
+    if runtime.is_available():
+        runtime_name = runtime.get_runtime_name()
+        return DependencyResult(
+            name="container_runtime",
+            passed=True,
+            description=f"Container runtime available ({runtime_name})",
+            required=False,
+        )
+    else:
+        return DependencyResult(
+            name="container_runtime",
+            passed=False,
+            description="No container runtime found",
+            fix_instructions=runtime.get_recommended_action(),
+            required=False,  # Warning only, doesn't block init
+        )
+
+
+def check_all_dependencies(repo_path: Path) -> Tuple[bool, List[DependencyResult]]:
+    """Run all dependency checks and collect results.
+
+    Checks are run in order:
+    1. Git repository (required)
+    2. gh CLI installed (required)
+    3. gh CLI authenticated (required, but skipped if gh not installed)
+    4. Container runtime (warning only)
+
+    Args:
+        repo_path: Path to the repository being initialized
+
+    Returns:
+        Tuple of (success, results) where success is False only if a
+        required check fails
+    """
+    results: List[DependencyResult] = []
+
+    # Check git repo
+    git_result = check_git_repo(repo_path)
+    results.append(git_result)
+
+    # Check gh installed
+    gh_result = check_gh_installed()
+    results.append(gh_result)
+
+    # Check gh authenticated (only if gh is installed)
+    if gh_result.passed:
+        auth_result = check_gh_authenticated()
+        results.append(auth_result)
+    else:
+        # Skip auth check but note it was skipped
+        results.append(
+            DependencyResult(
+                name="gh_authenticated",
+                passed=False,
+                description="Skipped (gh not installed)",
+                fix_instructions="Install gh CLI first",
+                required=True,
+            )
+        )
+
+    # Check container runtime (warning only)
+    container_result = check_container_runtime()
+    results.append(container_result)
+
+    # Determine overall success - only required checks matter
+    required_checks = [r for r in results if r.required]
+    success = all(r.passed for r in required_checks)
+
+    return success, results
+
+
+def print_dependency_report(results: List[DependencyResult]) -> None:
+    """Print a formatted report of dependency check results.
+
+    Shows all checks (passed and failed) with status indicators.
+    Failed checks include fix instructions.
+    Warnings (required=False) use different styling.
+
+    Args:
+        results: List of DependencyResult objects to display
+    """
+    console = Console()
+
+    # Separate required failures, warnings, and passed
+    required_failures = [r for r in results if r.required and not r.passed]
+    warnings = [r for r in results if not r.required and not r.passed]
+    passed = [r for r in results if r.passed]
+
+    if required_failures or warnings:
+        console.print("\n[bold]AgentTree requires the following dependencies:[/bold]\n")
+
+    # Show required failures first
+    for result in required_failures:
+        console.print(f"[red]\u2717[/red] [bold]{result.description}[/bold]")
+        if result.fix_instructions:
+            console.print(f"  [dim]Why:[/dim] AgentTree needs this to manage issues and PRs")
+            console.print(f"  [dim]Fix:[/dim] {result.fix_instructions}")
+        console.print()
+
+    # Show warnings
+    for result in warnings:
+        console.print(f"[yellow]\u26A0[/yellow] [bold]{result.description}[/bold] [dim](warning)[/dim]")
+        if result.fix_instructions:
+            console.print(f"  [dim]Why:[/dim] Agents run in sandboxed containers for safety")
+            console.print(f"  [dim]Fix:[/dim] {result.fix_instructions}")
+        console.print()
+
+    # Show passed checks
+    for result in passed:
+        console.print(f"[green]\u2713[/green] {result.description}")
+
+    if required_failures:
+        console.print("\n[yellow]Please resolve the issues above and run `agenttree init` again.[/yellow]")

--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -1,0 +1,362 @@
+"""Tests for dependency checking module."""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import Mock, patch, MagicMock
+
+import pytest
+
+from agenttree.dependencies import (
+    DependencyResult,
+    check_git_repo,
+    check_gh_installed,
+    check_gh_authenticated,
+    check_container_runtime,
+    check_all_dependencies,
+    print_dependency_report,
+)
+
+
+class TestDependencyResult:
+    """Tests for DependencyResult dataclass."""
+
+    def test_create_passing_result(self):
+        result = DependencyResult(
+            name="test",
+            passed=True,
+            description="Test passed",
+        )
+        assert result.name == "test"
+        assert result.passed is True
+        assert result.description == "Test passed"
+        assert result.fix_instructions is None
+        assert result.required is True
+
+    def test_create_failing_result_with_fix(self):
+        result = DependencyResult(
+            name="test",
+            passed=False,
+            description="Test failed",
+            fix_instructions="Run this command",
+            required=True,
+        )
+        assert result.passed is False
+        assert result.fix_instructions == "Run this command"
+
+    def test_create_warning_result(self):
+        result = DependencyResult(
+            name="container",
+            passed=False,
+            description="No container runtime",
+            fix_instructions="Install Docker",
+            required=False,  # Warning only
+        )
+        assert result.required is False
+
+
+class TestCheckGitRepo:
+    """Tests for check_git_repo function."""
+
+    def test_check_git_repo_success(self, tmp_path: Path):
+        """Test that check passes when .git directory exists."""
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+
+        result = check_git_repo(tmp_path)
+
+        assert result.passed is True
+        assert result.name == "git_repo"
+        assert "Git repository" in result.description
+
+    def test_check_git_repo_failure(self, tmp_path: Path):
+        """Test that check fails when .git directory is missing."""
+        result = check_git_repo(tmp_path)
+
+        assert result.passed is False
+        assert result.name == "git_repo"
+        assert "Not a git repository" in result.description
+        assert result.fix_instructions is not None
+        assert "git init" in result.fix_instructions
+
+
+class TestCheckGhInstalled:
+    """Tests for check_gh_installed function."""
+
+    def test_check_gh_installed_success(self):
+        """Test that check passes when gh CLI is found."""
+        with patch("shutil.which") as mock_which:
+            mock_which.return_value = "/usr/local/bin/gh"
+
+            result = check_gh_installed()
+
+            assert result.passed is True
+            assert result.name == "gh_installed"
+            assert "GitHub CLI" in result.description
+
+    def test_check_gh_installed_failure(self):
+        """Test that check fails when gh CLI is not found."""
+        with patch("shutil.which") as mock_which:
+            mock_which.return_value = None
+
+            result = check_gh_installed()
+
+            assert result.passed is False
+            assert result.name == "gh_installed"
+            assert "not installed" in result.description.lower()
+            assert result.fix_instructions is not None
+            assert "https://cli.github.com" in result.fix_instructions
+
+
+class TestCheckGhAuthenticated:
+    """Tests for check_gh_authenticated function."""
+
+    def test_check_gh_authenticated_success(self):
+        """Test that check passes when gh auth status returns 0."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = Mock(returncode=0, stdout="Logged in")
+
+            result = check_gh_authenticated()
+
+            assert result.passed is True
+            assert result.name == "gh_authenticated"
+            assert "authenticated" in result.description.lower()
+
+    def test_check_gh_authenticated_failure(self):
+        """Test that check fails when gh auth status returns non-zero."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = Mock(returncode=1, stderr="Not logged in")
+
+            result = check_gh_authenticated()
+
+            assert result.passed is False
+            assert result.name == "gh_authenticated"
+            assert "not authenticated" in result.description.lower()
+            assert result.fix_instructions is not None
+            assert "gh auth login" in result.fix_instructions
+
+    def test_check_gh_authenticated_timeout(self):
+        """Test that check handles timeout gracefully."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired(cmd="gh", timeout=5)
+
+            result = check_gh_authenticated()
+
+            assert result.passed is False
+            assert "timeout" in result.description.lower() or "timed out" in result.description.lower()
+
+    def test_check_gh_authenticated_file_not_found(self):
+        """Test that check handles missing gh executable."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.side_effect = FileNotFoundError("gh not found")
+
+            result = check_gh_authenticated()
+
+            assert result.passed is False
+
+
+class TestCheckContainerRuntime:
+    """Tests for check_container_runtime function."""
+
+    def test_check_container_runtime_docker(self):
+        """Test that check passes when Docker is available."""
+        with patch("agenttree.dependencies.ContainerRuntime") as mock_runtime_class:
+            mock_runtime = Mock()
+            mock_runtime.is_available.return_value = True
+            mock_runtime.get_runtime_name.return_value = "docker"
+            mock_runtime_class.return_value = mock_runtime
+
+            result = check_container_runtime()
+
+            assert result.passed is True
+            assert result.name == "container_runtime"
+            assert "docker" in result.description.lower()
+            assert result.required is False  # Container is a warning
+
+    def test_check_container_runtime_apple(self):
+        """Test that check passes when Apple Containers is available."""
+        with patch("agenttree.dependencies.ContainerRuntime") as mock_runtime_class:
+            mock_runtime = Mock()
+            mock_runtime.is_available.return_value = True
+            mock_runtime.get_runtime_name.return_value = "container"
+            mock_runtime_class.return_value = mock_runtime
+
+            result = check_container_runtime()
+
+            assert result.passed is True
+            assert "container" in result.description.lower()
+            assert result.required is False
+
+    def test_check_container_runtime_none(self):
+        """Test that check returns warning when no runtime is available."""
+        with patch("agenttree.dependencies.ContainerRuntime") as mock_runtime_class:
+            mock_runtime = Mock()
+            mock_runtime.is_available.return_value = False
+            mock_runtime.get_runtime_name.return_value = "none"
+            mock_runtime.get_recommended_action.return_value = "Install Docker"
+            mock_runtime_class.return_value = mock_runtime
+
+            result = check_container_runtime()
+
+            assert result.passed is False
+            assert result.name == "container_runtime"
+            assert result.required is False  # Warning only, not a failure
+            assert result.fix_instructions is not None
+
+
+class TestCheckAllDependencies:
+    """Tests for check_all_dependencies function."""
+
+    def test_check_all_all_pass(self, tmp_path: Path):
+        """Test that success is returned when all checks pass."""
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+
+        with patch("shutil.which") as mock_which, \
+             patch("subprocess.run") as mock_run, \
+             patch("agenttree.dependencies.ContainerRuntime") as mock_runtime_class:
+            mock_which.return_value = "/usr/local/bin/gh"
+            mock_run.return_value = Mock(returncode=0, stdout="Logged in")
+            mock_runtime = Mock()
+            mock_runtime.is_available.return_value = True
+            mock_runtime.get_runtime_name.return_value = "docker"
+            mock_runtime_class.return_value = mock_runtime
+
+            success, results = check_all_dependencies(tmp_path)
+
+            assert success is True
+            assert len(results) >= 3  # At least git, gh, gh_auth
+            required_checks = [r for r in results if r.required]
+            assert all(r.passed for r in required_checks)
+
+    def test_check_all_one_failure(self, tmp_path: Path):
+        """Test that failure is returned when a required check fails."""
+        # No .git directory - git check will fail
+        with patch("shutil.which") as mock_which, \
+             patch("subprocess.run") as mock_run, \
+             patch("agenttree.dependencies.ContainerRuntime") as mock_runtime_class:
+            mock_which.return_value = "/usr/local/bin/gh"
+            mock_run.return_value = Mock(returncode=0)
+            mock_runtime = Mock()
+            mock_runtime.is_available.return_value = True
+            mock_runtime.get_runtime_name.return_value = "docker"
+            mock_runtime_class.return_value = mock_runtime
+
+            success, results = check_all_dependencies(tmp_path)
+
+            assert success is False
+            # Find the git check result
+            git_result = next((r for r in results if r.name == "git_repo"), None)
+            assert git_result is not None
+            assert git_result.passed is False
+
+    def test_check_all_multiple_failures(self, tmp_path: Path):
+        """Test that all failures are collected and returned."""
+        # No .git, no gh
+        with patch("shutil.which") as mock_which, \
+             patch("agenttree.dependencies.ContainerRuntime") as mock_runtime_class:
+            mock_which.return_value = None  # gh not installed
+            mock_runtime = Mock()
+            mock_runtime.is_available.return_value = False
+            mock_runtime.get_runtime_name.return_value = "none"
+            mock_runtime.get_recommended_action.return_value = "Install Docker"
+            mock_runtime_class.return_value = mock_runtime
+
+            success, results = check_all_dependencies(tmp_path)
+
+            assert success is False
+            # Should have multiple failures
+            failed_required = [r for r in results if r.required and not r.passed]
+            assert len(failed_required) >= 2  # git and gh_installed at least
+
+    def test_check_all_container_warning_not_fatal(self, tmp_path: Path):
+        """Test that container check failure doesn't block success."""
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+
+        with patch("shutil.which") as mock_which, \
+             patch("subprocess.run") as mock_run, \
+             patch("agenttree.dependencies.ContainerRuntime") as mock_runtime_class:
+            mock_which.return_value = "/usr/local/bin/gh"
+            mock_run.return_value = Mock(returncode=0)
+            mock_runtime = Mock()
+            mock_runtime.is_available.return_value = False  # No container
+            mock_runtime.get_runtime_name.return_value = "none"
+            mock_runtime.get_recommended_action.return_value = "Install Docker"
+            mock_runtime_class.return_value = mock_runtime
+
+            success, results = check_all_dependencies(tmp_path)
+
+            # Should still succeed because container is a warning
+            assert success is True
+            container_result = next((r for r in results if r.name == "container_runtime"), None)
+            assert container_result is not None
+            assert container_result.passed is False
+            assert container_result.required is False
+
+    def test_check_all_skips_auth_when_gh_missing(self, tmp_path: Path):
+        """Test that gh auth check is skipped when gh is not installed."""
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+
+        with patch("shutil.which") as mock_which, \
+             patch("subprocess.run") as mock_run, \
+             patch("agenttree.dependencies.ContainerRuntime") as mock_runtime_class:
+            mock_which.return_value = None  # gh not installed
+            mock_runtime = Mock()
+            mock_runtime.is_available.return_value = True
+            mock_runtime.get_runtime_name.return_value = "docker"
+            mock_runtime_class.return_value = mock_runtime
+
+            success, results = check_all_dependencies(tmp_path)
+
+            # gh_authenticated should be skipped (not in results) or marked as skipped
+            auth_result = next((r for r in results if r.name == "gh_authenticated"), None)
+            # Either not present or marked as skipped
+            if auth_result is not None:
+                # If present, it should indicate it was skipped
+                assert "skipped" in auth_result.description.lower() or not auth_result.required
+            # subprocess.run should not have been called for auth
+            # (it would fail since gh is not installed)
+
+
+class TestPrintDependencyReport:
+    """Tests for print_dependency_report function."""
+
+    def test_format_results_shows_all(self, capsys):
+        """Test that report displays both passed and failed checks."""
+        results = [
+            DependencyResult(
+                name="git_repo",
+                passed=True,
+                description="Git repository detected",
+            ),
+            DependencyResult(
+                name="gh_installed",
+                passed=False,
+                description="GitHub CLI not installed",
+                fix_instructions="Install from https://cli.github.com",
+            ),
+        ]
+
+        print_dependency_report(results)
+        captured = capsys.readouterr()
+
+        # Both results should appear in output
+        assert "git" in captured.out.lower()
+        assert "github cli" in captured.out.lower()
+
+    def test_format_results_failure_includes_fix(self, capsys):
+        """Test that failed checks show fix instructions."""
+        results = [
+            DependencyResult(
+                name="gh_installed",
+                passed=False,
+                description="GitHub CLI not installed",
+                fix_instructions="Install from https://cli.github.com",
+            ),
+        ]
+
+        print_dependency_report(results)
+        captured = capsys.readouterr()
+
+        assert "https://cli.github.com" in captured.out


### PR DESCRIPTION
## Summary
- Batch-checks all dependencies upfront in init script
- Improves initialization flow by reporting all missing deps at once

## Test plan
- [ ] Tests pass
- [ ] Type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)