### PR TITLE
[Issue 078] Async hook execution - optional parallel processing

### DIFF
--- a/agenttree/hooks.py
+++ b/agenttree/hooks.py
@@ -54,6 +54,7 @@ Hooks are configured in .agenttree.yaml via pre_completion and post_start lists:
 
 import re
 import subprocess
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -764,24 +765,59 @@ def run_host_hooks(hooks: List[Dict[str, Any]], context: Dict[str, Any]) -> None
 
     These hooks log errors but don't block operations.
 
+    Hooks can optionally run asynchronously (fire-and-forget) by setting `async: true`:
+    - `async: true` - Start command immediately, don't wait for completion. Errors
+      are logged when they complete.
+    - No `async` or `async: false` - Wait for completion before proceeding (default)
+
+    Thread pool is limited to 5 concurrent workers to prevent resource exhaustion.
+
     Args:
         hooks: List of hook configurations
         context: Template variables for substitution (issue_id, pr_number, etc.)
     """
     from pathlib import Path
 
+    # Create executor for async hooks (max 5 concurrent)
+    executor = ThreadPoolExecutor(max_workers=5)
+
+    def execute_hook_sync(hook: Dict[str, Any]) -> List[str]:
+        """Execute a single hook synchronously and return errors."""
+        if "command" in hook:
+            return run_command_hook(
+                Path.cwd(),
+                hook,
+                issue_id=context.get("issue_id", ""),
+                issue_title=context.get("issue_title", ""),
+                branch=context.get("branch", ""),
+                pr_number=str(context.get("pr_number", "")),
+                pr_url=context.get("pr_url", ""),
+            )
+        return []
+
+    def async_done_callback(future: Any, hook: Dict[str, Any]) -> None:
+        """Log errors when async hook completes."""
+        try:
+            errors = future.result()
+            for error in errors:
+                console.print(f"[yellow]Warning (async): {error}[/yellow]")
+        except Exception as e:
+            console.print(f"[yellow]Hook error (async): {e}[/yellow]")
+
     for hook in hooks:
         try:
-            if "command" in hook:
-                errors = run_command_hook(
-                    Path.cwd(),
-                    hook,
-                    issue_id=context.get("issue_id", ""),
-                    issue_title=context.get("issue_title", ""),
-                    branch=context.get("branch", ""),
-                    pr_number=str(context.get("pr_number", "")),
-                    pr_url=context.get("pr_url", ""),
-                )
+            is_async = hook.get("async", False)
+
+            if is_async:
+                # Fire-and-forget: submit to thread pool and continue
+                future = executor.submit(execute_hook_sync, hook)
+                # Add callback to log errors when done (capture hook in closure)
+                def make_callback(h: Dict[str, Any]) -> Any:
+                    return lambda f: async_done_callback(f, h)
+                future.add_done_callback(make_callback(hook))
+            else:
+                # Synchronous: execute and wait for completion
+                errors = execute_hook_sync(hook)
                 for error in errors:
                     console.print(f"[yellow]Warning: {error}[/yellow]")
         except Exception as e:

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -1546,3 +1546,138 @@ class TestPreCompletionPostStartHooks:
         mock_execute_hooks.assert_called_once()
         call_args = mock_execute_hooks.call_args
         assert call_args[0][3] == "post_start"
+
+
+class TestAsyncHookExecution:
+    """Tests for async hook execution (fire-and-forget mode)."""
+
+    def test_async_hook_does_not_block(self, tmp_path):
+        """Async hook should return immediately without waiting for command completion."""
+        import time
+        from agenttree.hooks import run_host_hooks
+
+        # Use a slow command that takes 2 seconds
+        hooks = [{"command": "sleep 2", "async": True}]
+
+        start = time.monotonic()
+        run_host_hooks(hooks, {"issue_id": "001"})
+        elapsed = time.monotonic() - start
+
+        # Should return in less than 1 second (generous threshold for CI)
+        assert elapsed < 1.0, f"Async hook blocked for {elapsed:.2f}s, expected < 1.0s"
+
+    def test_sync_hook_blocks_until_complete(self, tmp_path):
+        """Sync hook (default) should block until command completes."""
+        from agenttree.hooks import run_host_hooks
+
+        marker = tmp_path / "marker.txt"
+        hooks = [{"command": f"touch {marker}"}]
+
+        run_host_hooks(hooks, {"issue_id": "001"})
+
+        # File should exist after sync hook completes
+        assert marker.exists(), "Sync hook did not complete before returning"
+
+    def test_mixed_async_and_sync_hooks(self, tmp_path):
+        """Sync hooks should complete in order while async hooks run in background."""
+        from agenttree.hooks import run_host_hooks
+
+        sync_marker = tmp_path / "sync_marker.txt"
+        hooks = [
+            {"command": "sleep 1", "async": True},  # Async hook 1
+            {"command": f"touch {sync_marker}"},     # Sync hook (should complete)
+            {"command": "sleep 1", "async": True},  # Async hook 2
+        ]
+
+        run_host_hooks(hooks, {"issue_id": "001"})
+
+        # Sync marker should exist (sync hook completed)
+        assert sync_marker.exists(), "Sync hook did not complete"
+
+    def test_async_hook_errors_logged(self, tmp_path, capsys):
+        """Errors from async hooks should be logged, not raised."""
+        import time
+        from agenttree.hooks import run_host_hooks
+
+        hooks = [{"command": "exit 1", "async": True}]
+
+        # Should not raise
+        run_host_hooks(hooks, {"issue_id": "001"})
+
+        # Give a brief moment for async error logging
+        time.sleep(0.2)
+
+        # Note: Async errors may be logged asynchronously, so we can't guarantee
+        # the exact timing of the output. The key behavior is that no exception
+        # is raised.
+
+    @patch('agenttree.hooks.is_running_in_container', return_value=True)
+    def test_async_hook_respects_host_only(self, mock_container, tmp_path):
+        """Async hook with host_only should skip execution in container."""
+        from agenttree.hooks import run_host_hooks
+
+        marker = tmp_path / "marker.txt"
+        hooks = [{"command": f"touch {marker}", "async": True, "host_only": True}]
+
+        run_host_hooks(hooks, {"issue_id": "001"})
+
+        # File should NOT be created because we're "in container"
+        assert not marker.exists()
+
+    def test_async_hook_variable_substitution(self, tmp_path):
+        """Template variables should be substituted before async execution."""
+        import time
+        from agenttree.hooks import run_host_hooks
+
+        output_file = tmp_path / "output.txt"
+        hooks = [{"command": f"echo '{{{{issue_id}}}}' > {output_file}", "async": True}]
+
+        run_host_hooks(hooks, {"issue_id": "042"})
+
+        # Wait for async command to complete
+        time.sleep(0.5)
+
+        content = output_file.read_text().strip()
+        assert content == "042", f"Expected '042', got '{content}'"
+
+    def test_multiple_async_hooks_parallel(self, tmp_path):
+        """Multiple async hooks should run concurrently, not sequentially."""
+        import time
+        from agenttree.hooks import run_host_hooks
+
+        # Three commands that each take ~0.5 seconds
+        marker1 = tmp_path / "marker1.txt"
+        marker2 = tmp_path / "marker2.txt"
+        marker3 = tmp_path / "marker3.txt"
+        hooks = [
+            {"command": f"sleep 0.5 && touch {marker1}", "async": True},
+            {"command": f"sleep 0.5 && touch {marker2}", "async": True},
+            {"command": f"sleep 0.5 && touch {marker3}", "async": True},
+        ]
+
+        start = time.monotonic()
+        run_host_hooks(hooks, {"issue_id": "001"})
+        elapsed = time.monotonic() - start
+
+        # Should return almost immediately (< 0.5s), not after 1.5s
+        assert elapsed < 0.5, f"Async hooks blocked for {elapsed:.2f}s, expected < 0.5s"
+
+        # Wait for all async commands to complete
+        time.sleep(1.0)
+
+        # All markers should exist
+        assert marker1.exists(), "Async hook 1 did not complete"
+        assert marker2.exists(), "Async hook 2 did not complete"
+        assert marker3.exists(), "Async hook 3 did not complete"
+
+    def test_async_false_is_sync(self, tmp_path):
+        """async: false should behave the same as omitting the flag (synchronous)."""
+        from agenttree.hooks import run_host_hooks
+
+        marker = tmp_path / "marker.txt"
+        hooks = [{"command": f"touch {marker}", "async": False}]
+
+        run_host_hooks(hooks, {"issue_id": "001"})
+
+        # File should exist after hook completes (sync behavior)
+        assert marker.exists(), "async: false did not behave synchronously"


### PR DESCRIPTION
## Summary
- Adds optional async/parallel hook execution
- Hooks can now run concurrently when configured

## Test plan
- [ ] Tests pass
- [ ] Type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)