### PR TITLE
Add New Issue button to kanban header

### DIFF
--- a/agenttree/web/static/styles.css
+++ b/agenttree/web/static/styles.css
@@ -154,6 +154,33 @@ header h1 {
     background: var(--btn-bg-hover);
 }
 
+.btn-new-issue {
+    margin-left: 15px;
+    padding: 6px 14px;
+    background: #5d8a6b;
+    border: 1px solid #4a7359;
+    border-radius: 4px;
+    color: #f8f6f0;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.btn-new-issue:hover {
+    background: #4a7359;
+    border-color: #3d6149;
+}
+
+[data-theme="dark"] .btn-new-issue {
+    background: #3d6b5a;
+    border-color: #2d5a4a;
+}
+
+[data-theme="dark"] .btn-new-issue:hover {
+    background: #4a7d68;
+}
+
 /* ==============================================
    Buttons
    ============================================== */
@@ -1416,4 +1443,74 @@ button[disabled] {
 
 .flow-sidebar .issue-item[data-stage="not_doing"] {
     border-left-color: #ef4444;
+}
+
+/* ==============================================
+   New Issue Modal
+   ============================================== */
+
+.new-issue-modal-content {
+    max-width: 500px;
+    height: auto;
+    max-height: 400px;
+    padding: 30px;
+}
+
+.new-issue-form-container h2 {
+    margin: 0 0 25px 0;
+    color: var(--text-accent);
+    font-size: 20px;
+    font-weight: 600;
+}
+
+.form-group {
+    margin-bottom: 20px;
+}
+
+.form-group label {
+    display: block;
+    margin-bottom: 6px;
+    font-weight: 500;
+    color: var(--text-primary);
+    font-size: 14px;
+}
+
+.form-group input[type="text"],
+.form-group select {
+    width: 100%;
+    padding: 10px 12px;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    background: var(--bg-card);
+    color: var(--text-primary);
+    font-size: 14px;
+    transition: border-color 0.2s;
+}
+
+.form-group input[type="text"]:focus,
+.form-group select:focus {
+    outline: none;
+    border-color: var(--text-accent);
+}
+
+.form-group input[type="text"]::placeholder {
+    color: var(--text-muted);
+}
+
+.form-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+    margin-top: 25px;
+}
+
+.form-error {
+    color: #dc2626;
+    font-size: 13px;
+    margin-top: 15px;
+    min-height: 20px;
+}
+
+[data-theme="dark"] .form-error {
+    color: #f87171;
 }

--- a/agenttree/web/templates/kanban.html
+++ b/agenttree/web/templates/kanban.html
@@ -58,6 +58,37 @@
         </div>
     </div>
 
+    <!-- Modal for new issue -->
+    <div id="new-issue-modal" class="modal">
+        <div class="modal-content new-issue-modal-content">
+            <button class="modal-close" onclick="closeNewIssueModal()">&times;</button>
+            <div class="new-issue-form-container">
+                <h2>Create New Issue</h2>
+                <form id="new-issue-form" onsubmit="submitNewIssue(event)">
+                    <div class="form-group">
+                        <label for="issue-title">Title</label>
+                        <input type="text" id="issue-title" name="title" required minlength="10"
+                               placeholder="Issue title (min 10 characters)">
+                    </div>
+                    <div class="form-group">
+                        <label for="issue-priority">Priority</label>
+                        <select id="issue-priority" name="priority">
+                            <option value="low">Low</option>
+                            <option value="medium" selected>Medium</option>
+                            <option value="high">High</option>
+                            <option value="critical">Critical</option>
+                        </select>
+                    </div>
+                    <div class="form-actions">
+                        <button type="button" class="btn" onclick="closeNewIssueModal()">Cancel</button>
+                        <button type="submit" class="btn btn-primary" id="create-issue-btn">Create Issue</button>
+                    </div>
+                    <div id="new-issue-error" class="form-error"></div>
+                </form>
+            </div>
+        </div>
+    </div>
+
     <script>
     (function() {
         // Wrap in IIFE to avoid duplicate declarations on HTMX swaps
@@ -197,8 +228,12 @@
 
         // Close modal on escape key
         document.addEventListener('keydown', (e) => {
-            if (e.key === 'Escape' && document.getElementById('issue-modal').classList.contains('active')) {
-                window.closeIssueModal();
+            if (e.key === 'Escape') {
+                if (document.getElementById('new-issue-modal').classList.contains('active')) {
+                    window.closeNewIssueModal();
+                } else if (document.getElementById('issue-modal').classList.contains('active')) {
+                    window.closeIssueModal();
+                }
             }
         });
 
@@ -211,6 +246,63 @@
                 }
             });
         }
+
+        // New issue modal on background click
+        const newIssueModal = document.getElementById('new-issue-modal');
+        if (newIssueModal) {
+            newIssueModal.addEventListener('click', (e) => {
+                if (e.target.id === 'new-issue-modal') {
+                    window.closeNewIssueModal();
+                }
+            });
+        }
+
+        // New issue modal functions
+        window.openNewIssueModal = function() {
+            document.getElementById('new-issue-modal').classList.add('active');
+            document.getElementById('issue-title').focus();
+        };
+
+        window.closeNewIssueModal = function() {
+            document.getElementById('new-issue-modal').classList.remove('active');
+            document.getElementById('new-issue-form').reset();
+            document.getElementById('new-issue-error').textContent = '';
+        };
+
+        window.submitNewIssue = async function(event) {
+            event.preventDefault();
+            const form = document.getElementById('new-issue-form');
+            const formData = new FormData(form);
+            const errorDiv = document.getElementById('new-issue-error');
+            const submitBtn = document.getElementById('create-issue-btn');
+
+            // Disable button while submitting
+            submitBtn.disabled = true;
+            submitBtn.textContent = 'Creating...';
+            errorDiv.textContent = '';
+
+            try {
+                const response = await fetch('/api/issues', {
+                    method: 'POST',
+                    body: formData
+                });
+
+                const data = await response.json();
+
+                if (response.ok) {
+                    // Success - reload the page to show new issue
+                    location.reload();
+                } else {
+                    errorDiv.textContent = data.detail || 'Failed to create issue';
+                    submitBtn.disabled = false;
+                    submitBtn.textContent = 'Create Issue';
+                }
+            } catch (error) {
+                errorDiv.textContent = 'Error creating issue: ' + error.message;
+                submitBtn.disabled = false;
+                submitBtn.textContent = 'Create Issue';
+            }
+        };
 
         // Stage toggle functionality
         const reviewStages = ['backlog', 'plan_review', 'implementation_review'];

--- a/agenttree/web/templates/partials/header.html
+++ b/agenttree/web/templates/partials/header.html
@@ -11,6 +11,7 @@
             <button class="toggle-btn" onclick="setStageView('nonempty')" id="toggle-nonempty">Non-Empty</button>
             <button class="toggle-btn" onclick="setStageView('all')" id="toggle-all">All Stages</button>
         </div>
+        <button class="btn btn-new-issue" onclick="openNewIssueModal()">+ New Issue</button>
         {% endif %}
         <button class="theme-toggle" onclick="toggleTheme()" title="Toggle light/dark theme">
             <span class="theme-icon">🌙</span>


### PR DESCRIPTION
## Summary
- Adds "+ New Issue" button to kanban header
- Opens modal form with title and priority fields
- Creates issue via `POST /api/issues` endpoint
- Page reloads to show new issue in backlog

## Test plan
- [x] Button appears in kanban header
- [x] Modal opens on click
- [x] Form validates title (10+ chars)
- [x] Issue created and appears in backlog

Closes #056

🤖 Generated with [Claude Code](https://claude.com/claude-code)