### PR TITLE
[Issue 118] Color-code tmux web view - green for agent, black for user input

### DIFF
--- a/agenttree/web/static/styles.css
+++ b/agenttree/web/static/styles.css
@@ -953,6 +953,11 @@ button[disabled] {
     min-height: 0;
 }
 
+/* User input lines in tmux output - muted color to distinguish from agent output */
+.agent-chat-panel .tmux-output .tmux-user-input {
+    color: var(--text-muted);
+}
+
 .agent-chat-panel .tmux-input-container {
     padding: 10px;
     background: var(--bg-card);

--- a/agenttree/web/templates/partials/tmux_output.html
+++ b/agenttree/web/templates/partials/tmux_output.html
@@ -1,1 +1,1 @@
-<div class="tmux-output" id="tmux-output-{{ agent_num }}">{{ output }}</div>
+<div class="tmux-output" id="tmux-output-{{ agent_num }}">{{ output | safe }}</div>


### PR DESCRIPTION
## Summary

Implementation for **Issue #118**: Color-code tmux web view - green for agent, black for user input

**Issue link:** [View in AgentTree Flow](http://localhost:8080/flow?issue=118)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)