### PR TITLE
[Issue 120] Add CLI command to get issue field values and expand template variables

### DIFF
--- a/agenttree/hooks.py
+++ b/agenttree/hooks.py
@@ -293,6 +293,7 @@ from agenttree.issues import (
     PLAN,
     IMPLEMENT,
     ACCEPTED,
+    get_issue_context,
 )
 from agenttree.config import load_config
 
@@ -953,7 +954,7 @@ def run_builtin_validator(
             if not dest_path.exists() and template_path.exists():
                 template_content = template_path.read_text()
 
-                # Build Jinja context
+                # Build Jinja context using unified function
                 from jinja2 import Template
                 from agenttree.commands import get_referenced_commands, get_command_output
 
@@ -961,21 +962,8 @@ def run_builtin_validator(
                 context: Dict[str, Any] = {}
 
                 if issue:
-                    context = {
-                        "issue_id": issue.id,
-                        "issue_title": issue.title,
-                        "issue_dir": str(issue_dir),
-                        "issue_dir_rel": f"_agenttree/issues/{issue.id}-{issue.slug}" if hasattr(issue, 'slug') else "",
-                    }
-
-                    # Add document contents if they exist
-                    for doc_name in ["problem.md", "research.md", "spec.md", "spec_review.md", "review.md"]:
-                        doc_path = issue_dir / doc_name
-                        var_name = doc_name.replace(".md", "_md").replace("-", "_")
-                        if doc_path.exists():
-                            context[var_name] = doc_path.read_text()
-                        else:
-                            context[var_name] = ""
+                    # Use get_issue_context for all issue fields
+                    context = get_issue_context(issue, include_docs=True)
 
                     # Add latest_independent_review - find highest-numbered version
                     # Looks for independent_review_v*.md and uses the highest version

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -348,17 +348,20 @@ This is the approach section with content.
         issue_dir = tmp_path / "issue"
         issue_dir.mkdir()
 
-        # Create a mock issue
-        mock_issue = MagicMock()
-        mock_issue.id = "046"
-        mock_issue.title = "Test Issue"
-        mock_issue.slug = "test-issue"
-        mock_issue.worktree_dir = None
+        # Create a real Issue object (get_issue_context requires Issue.model_dump)
+        test_issue = Issue(
+            id="046",
+            slug="test-issue",
+            title="Test Issue",
+            created="2026-01-11T12:00:00Z",
+            updated="2026-01-11T12:00:00Z",
+        )
 
         hook = {"type": "create_file", "template": "review.md", "dest": "review.md"}
 
         with patch('agenttree.hooks.load_config', return_value=Config()):
-            errors = run_builtin_validator(issue_dir, hook, issue=mock_issue)
+            with patch('agenttree.issues.get_issue_dir', return_value=issue_dir):
+                errors = run_builtin_validator(issue_dir, hook, issue=test_issue)
 
         assert errors == []
         mock_git_stats.assert_called_once()
@@ -388,17 +391,20 @@ This is the approach section with content.
         issue_dir = tmp_path / "issue"
         issue_dir.mkdir()
 
-        # Create a mock issue
-        mock_issue = MagicMock()
-        mock_issue.id = "042"
-        mock_issue.title = "Test Issue"
-        mock_issue.slug = "test-issue"
-        mock_issue.worktree_dir = None
+        # Create a real Issue object (get_issue_context requires Issue.model_dump)
+        test_issue = Issue(
+            id="042",
+            slug="test-issue",
+            title="Test Issue",
+            created="2026-01-11T12:00:00Z",
+            updated="2026-01-11T12:00:00Z",
+        )
 
         # Mock load_config to return empty commands
         with patch('agenttree.hooks.load_config', return_value=Config()):
-            hook = {"type": "create_file", "template": "test_review.md", "dest": "output.md"}
-            errors = run_builtin_validator(issue_dir, hook, issue=mock_issue)
+            with patch('agenttree.issues.get_issue_dir', return_value=issue_dir):
+                hook = {"type": "create_file", "template": "test_review.md", "dest": "output.md"}
+                errors = run_builtin_validator(issue_dir, hook, issue=test_issue)
 
         assert errors == []
 
@@ -426,19 +432,22 @@ This is the approach section with content.
         issue_dir = tmp_path / "issue"
         issue_dir.mkdir()
 
-        # Create a mock issue
-        mock_issue = MagicMock()
-        mock_issue.id = "001"
-        mock_issue.title = "Test"
-        mock_issue.slug = "test"
-        mock_issue.worktree_dir = None
+        # Create a real Issue object (get_issue_context requires Issue.model_dump)
+        test_issue = Issue(
+            id="001",
+            slug="test",
+            title="Test",
+            created="2026-01-11T12:00:00Z",
+            updated="2026-01-11T12:00:00Z",
+        )
 
         # Mock load_config to return commands and is_running_in_container to avoid /workspace
         mock_config = Config(commands={"git_branch": "echo 'feature-branch'"})
         with patch('agenttree.hooks.load_config', return_value=mock_config):
             with patch('agenttree.hooks.is_running_in_container', return_value=False):
-                hook = {"type": "create_file", "template": "stats.md", "dest": "output.md"}
-                errors = run_builtin_validator(issue_dir, hook, issue=mock_issue)
+                with patch('agenttree.issues.get_issue_dir', return_value=issue_dir):
+                    hook = {"type": "create_file", "template": "stats.md", "dest": "output.md"}
+                    errors = run_builtin_validator(issue_dir, hook, issue=test_issue)
 
         assert errors == []
 


### PR DESCRIPTION
## Summary

Implementation for **Issue #120**: Add CLI command to get issue field values and expand template variables

**Issue link:** [View in AgentTree Flow](http://localhost:8080/flow?issue=120)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)