### PR TITLE
Enforce branch workflow in CLAUDE.md rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,20 @@
 # AgentTree - Project Conventions
 
-## ⛔ NEVER merge your own PRs without explicit approval. Create PR → request `@cursoragent review` → WAIT for review → ASK before merging.
+## ⛔ Git Rules - READ FIRST
+
+1. **NEVER commit directly to main** - Always create a feature branch first
+2. **NEVER merge your own PRs** - Create PR → request review → WAIT → ASK before merging
+3. **NEVER push to main** - All changes go through PRs
+
+**Workflow:**
+```bash
+git checkout -b feature/my-change   # Create branch
+# ... make changes ...
+git add . && git commit -m "..."    # Commit to branch
+git push -u origin HEAD             # Push branch
+gh pr create --title "..." --body "..."  # Create PR
+# WAIT for review and approval
+```
 
 ## Tech Stack
 


### PR DESCRIPTION
## Summary
- Added explicit rules at the top of CLAUDE.md to prevent direct commits to main
- Rules now clearly state: NEVER commit to main, NEVER push to main, NEVER merge own PRs
- Added example workflow showing correct branch + PR process

## Why
I was committing directly to main today which violates project conventions. Making the rules more prominent and explicit.

## Test plan
- [ ] Verify CLAUDE.md renders correctly
- [ ] Rules are visible at top of file

Made with [Cursor](https://cursor.com)