### PR TITLE
[Issue 253] Add persistent voice chat widget to web UI with URL-aware context and navigation

### DIFF
--- a/agenttree/web/app.py
+++ b/agenttree/web/app.py
@@ -580,6 +580,7 @@ async def kanban(
             "search": search or "",
             "current_view": view or "nonempty",
             "rate_limit_warning": rate_limit_warning,
+            "has_openai_key": bool(os.environ.get("OPENAI_API_KEY")),
         }
     )
 
@@ -991,6 +992,7 @@ async def flow(
             "search": search or "",
             "current_sort": sort or "stage",
             "current_filter": filter or "all",
+            "has_openai_key": bool(os.environ.get("OPENAI_API_KEY")),
         }
     )
 
@@ -1667,6 +1669,14 @@ async def voice_tool_call(
     The browser receives function_call events from OpenAI, POSTs them
     here, and we return the result to send back via the data channel.
     """
+    body = await request.json()
+    fn_name = str(body.get("name", ""))
+    fn_args = dict(body.get("arguments", {}))
+
+    # navigate is handled client-side, but if it reaches the server, ack it
+    if fn_name == "navigate":
+        return {"result": "Navigation is handled client-side"}
+
     from agenttree.mcp_server import (
         status as mcp_status,
         get_issue as mcp_get_issue,
@@ -1677,10 +1687,6 @@ async def voice_tool_call(
         start_issue as mcp_start,
         stop_agent as mcp_stop,
     )
-
-    body = await request.json()
-    fn_name = str(body.get("name", ""))
-    fn_args = dict(body.get("arguments", {}))
 
     def _run_tool(name: str, args: dict[str, object]) -> str:
         tools: dict[str, Callable[[dict[str, object]], object]] = {

--- a/agenttree/web/routes/pages.py
+++ b/agenttree/web/routes/pages.py
@@ -138,6 +138,7 @@ async def kanban(
             "search": search or "",
             "current_view": view or "nonempty",
             "rate_limit_warning": rate_limit_warning,
+            "has_openai_key": bool(os.environ.get("OPENAI_API_KEY")),
         },
     )
 
@@ -239,6 +240,7 @@ async def flow(
             "search": search or "",
             "current_sort": sort or "stage",
             "current_filter": filter or "all",
+            "has_openai_key": bool(os.environ.get("OPENAI_API_KEY")),
         },
     )
 

--- a/agenttree/web/routes/voice.py
+++ b/agenttree/web/routes/voice.py
@@ -160,6 +160,21 @@ async def voice_token(
                 "required": ["issue_id"],
             },
         },
+        {
+            "type": "function",
+            "name": "navigate",
+            "description": "Navigate the user's browser to a URL within AgentTree. Use this when the user asks to see an issue, go to kanban, etc. Note: navigation causes a full page reload which disconnects the voice session.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "description": "Relative URL to navigate to, e.g. /kanban?issue=42 or /flow?issue=10",
+                    }
+                },
+                "required": ["url"],
+            },
+        },
     ]
 
     # OpenAI Realtime API GA endpoints (released Dec 2025):
@@ -202,6 +217,14 @@ async def voice_tool_call(
     The browser receives function_call events from OpenAI, POSTs them
     here, and we return the result to send back via the data channel.
     """
+    body = await request.json()
+    fn_name = str(body.get("name", ""))
+    fn_args = dict(body.get("arguments", {}))
+
+    # navigate is handled client-side, but if it reaches the server, ack it
+    if fn_name == "navigate":
+        return {"result": "Navigation is handled client-side"}
+
     from agenttree.mcp_server import (
         approve as mcp_approve,
         create_issue as mcp_create,
@@ -212,10 +235,6 @@ async def voice_tool_call(
         status as mcp_status,
         stop_agent as mcp_stop,
     )
-
-    body = await request.json()
-    fn_name = str(body.get("name", ""))
-    fn_args = dict(body.get("arguments", {}))
 
     def _run_tool(name: str, args: dict[str, object]) -> str:
         tools: dict[str, Callable[[dict[str, object]], object]] = {

--- a/agenttree/web/static/styles.css
+++ b/agenttree/web/static/styles.css
@@ -3155,3 +3155,84 @@ body:has(.rate-limit-banner) .kanban-board {
 .settings-actions .btn {
     padding: 10px 24px;
 }
+
+/* Voice widget dropdown */
+.voice-widget-dropdown {
+    display: none;
+    position: absolute;
+    top: 100%;
+    right: 80px;
+    width: 320px;
+    max-height: 300px;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+    z-index: 1000;
+    flex-direction: column;
+}
+
+.voice-widget-dropdown.open {
+    display: flex;
+}
+
+.voice-widget-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 12px;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.voice-widget-status {
+    font-size: 13px;
+    color: var(--text-secondary);
+}
+
+.voice-widget-status.active {
+    color: #22c55e;
+}
+
+.voice-widget-status.error {
+    color: #ef4444;
+}
+
+.voice-widget-close {
+    background: none;
+    border: none;
+    color: var(--text-secondary);
+    cursor: pointer;
+    padding: 2px;
+    line-height: 0;
+}
+
+.voice-widget-close:hover {
+    color: var(--text-primary);
+}
+
+.voice-widget-log {
+    flex: 1;
+    overflow-y: auto;
+    padding: 8px 12px;
+    font-size: 12px;
+    color: var(--text-secondary);
+    max-height: 240px;
+}
+
+.voice-widget-log div {
+    padding: 2px 0;
+}
+
+.voice-widget-log .tool-call {
+    color: var(--text-primary);
+    font-family: var(--font-mono, monospace);
+    font-size: 11px;
+}
+
+.header-icon-btn.voice-active {
+    color: #22c55e;
+}
+
+header .header-row {
+    position: relative;
+}

--- a/agenttree/web/static/voice.js
+++ b/agenttree/web/static/voice.js
@@ -16,6 +16,7 @@ class VoiceSession {
         this.onStatus = opts.onStatus || function() {};
         this.onLog = opts.onLog || function() {};
         this.getIssueId = opts.getIssueId || function() { return null; };
+        this.onNavigate = opts.onNavigate || null;
 
         this.pc = null;
         this.dc = null;
@@ -169,6 +170,24 @@ class VoiceSession {
         var fnArgs;
         try { fnArgs = JSON.parse(output.arguments || '{}'); } catch(e) { fnArgs = {}; }
         this.onLog('Tool: ' + fnName + '(' + JSON.stringify(fnArgs) + ')', 'tool-call');
+
+        // Handle navigate client-side without server round-trip
+        if (fnName === 'navigate' && this.onNavigate) {
+            var url = fnArgs.url || '/kanban';
+            if (this.dc && this.dc.readyState === 'open') {
+                this.dc.send(JSON.stringify({
+                    type: 'conversation.item.create',
+                    item: {
+                        type: 'function_call_output',
+                        call_id: output.call_id,
+                        output: 'Navigating to ' + url,
+                    },
+                }));
+                this.dc.send(JSON.stringify({ type: 'response.create' }));
+            }
+            this.onNavigate(url);
+            return;
+        }
 
         try {
             var resp = await fetch('/api/voice/tool-call', {

--- a/agenttree/web/templates/flow.html
+++ b/agenttree/web/templates/flow.html
@@ -14,6 +14,11 @@
 <body>
     {% include 'partials/header.html' %}
 
+    {% if has_openai_key %}
+    <script src="/static/voice.js"></script>
+    {% include 'partials/voice_widget.html' %}
+    {% endif %}
+
     <div class="flow-container">
         <!-- Left sidebar: Issue list (no polling - refresh page for updates) -->
         <div class="flow-sidebar">

--- a/agenttree/web/templates/kanban.html
+++ b/agenttree/web/templates/kanban.html
@@ -14,6 +14,11 @@
 <body>
     {% include 'partials/header.html' %}
 
+    {% if has_openai_key %}
+    <script src="/static/voice.js"></script>
+    {% include 'partials/voice_widget.html' %}
+    {% endif %}
+
     <!-- Rate limit warning banner -->
     {% if rate_limit_warning %}
     <div id="rate-limit-banner" class="rate-limit-banner{% if rate_limit_warning.mode == 'api_key' %} api-mode{% endif %}">

--- a/agenttree/web/templates/partials/header.html
+++ b/agenttree/web/templates/partials/header.html
@@ -61,6 +61,16 @@
         {% if request.query_params.get('issue') %}
         <input type="hidden" name="issue" value="{{ request.query_params.get('issue') }}" class="search-preserve">
         {% endif %}
+        {% if has_openai_key is defined and has_openai_key %}
+        <button class="header-icon-btn" id="voice-widget-btn" onclick="window.toggleVoiceWidget()" title="Voice chat">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/>
+                <path d="M19 10v2a7 7 0 0 1-14 0v-2"/>
+                <line x1="12" y1="19" x2="12" y2="23"/>
+                <line x1="8" y1="23" x2="16" y2="23"/>
+            </svg>
+        </button>
+        {% endif %}
         <a href="/settings" class="header-icon-btn" title="Settings">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <circle cx="12" cy="12" r="3"></circle>

--- a/agenttree/web/templates/partials/voice_widget.html
+++ b/agenttree/web/templates/partials/voice_widget.html
@@ -1,0 +1,66 @@
+<!-- Voice chat widget dropdown (shown when mic button is clicked) -->
+<div class="voice-widget-dropdown" id="voice-widget-dropdown">
+    <div class="voice-widget-header">
+        <span class="voice-widget-status" id="vw-status">Click mic to start</span>
+        <button class="voice-widget-close" onclick="window.toggleVoiceWidget()">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="16" height="16">
+                <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+            </svg>
+        </button>
+    </div>
+    <div class="voice-widget-log" id="vw-log"></div>
+</div>
+
+<script>
+(function() {
+    var voiceWidget = new VoiceSession({
+        onStatus: function(text, state) {
+            var statusEl = document.getElementById('vw-status');
+            var btn = document.getElementById('voice-widget-btn');
+            if (!statusEl || !btn) return;
+
+            statusEl.textContent = text;
+            statusEl.className = 'voice-widget-status' + (state === 'active' ? ' active' : state === 'error' ? ' error' : '');
+
+            if (state === 'active') {
+                btn.classList.add('voice-active');
+            } else if (state === 'idle' || state === 'error') {
+                btn.classList.remove('voice-active');
+            }
+        },
+        onLog: function(text, className) {
+            var el = document.getElementById('vw-log');
+            if (!el) return;
+            var div = document.createElement('div');
+            div.textContent = text;
+            if (className) div.className = className;
+            el.appendChild(div);
+            el.scrollTop = el.scrollHeight;
+        },
+        getIssueId: function() {
+            var params = new URLSearchParams(window.location.search);
+            var issue = params.get('issue');
+            return issue ? parseInt(issue, 10) : null;
+        },
+        onNavigate: function(url) {
+            window.location.href = url;
+        },
+    });
+
+    var dropdownOpen = false;
+
+    window.toggleVoiceWidget = function() {
+        var dropdown = document.getElementById('voice-widget-dropdown');
+        if (!dropdown) return;
+
+        dropdownOpen = !dropdownOpen;
+        dropdown.classList.toggle('open', dropdownOpen);
+
+        if (dropdownOpen && !voiceWidget.active) {
+            voiceWidget.start();
+        } else if (!dropdownOpen && voiceWidget.active) {
+            voiceWidget.stop();
+        }
+    };
+})();
+</script>

--- a/tests/unit/test_voice_widget.py
+++ b/tests/unit/test_voice_widget.py
@@ -1,0 +1,99 @@
+"""Tests for voice widget: navigate tool definition and has_openai_key context passing."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+
+pytestmark = pytest.mark.local_only
+
+from starlette.testclient import TestClient
+
+from agenttree.web.app import app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(app)
+
+
+class TestNavigateToolDefinition:
+    """Verify the navigate tool is included in voice session tools."""
+
+    def test_navigate_tool_in_voice_route_tools(self) -> None:
+        """The navigate tool should be defined in the tools list in voice.py."""
+        from agenttree.web.routes import voice as voice_module
+        import inspect
+
+        source = inspect.getsource(voice_module.voice_token)
+        assert '"navigate"' in source
+        assert '"url"' in source
+
+    def test_navigate_tool_call_returns_client_side_message(
+        self, client: TestClient
+    ) -> None:
+        """The navigate tool call endpoint should return a client-side message."""
+        response = client.post(
+            "/api/voice/tool-call",
+            json={"name": "navigate", "arguments": {"url": "/kanban?issue=42"}},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert "client-side" in data["result"].lower()
+
+
+class TestHasOpenaiKeyContext:
+    """Verify has_openai_key is passed to kanban and flow page contexts."""
+
+    @patch("agenttree.web.app.get_kanban_board")
+    def test_kanban_passes_has_openai_key_true(
+        self,
+        mock_board: MagicMock,
+        client: TestClient,
+    ) -> None:
+        """Kanban page should pass has_openai_key=True when env var is set."""
+        mock_board.return_value = {}
+        with patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"}):
+            response = client.get("/kanban")
+        assert response.status_code == 200
+        assert "voice-widget-btn" in response.text
+
+    @patch("agenttree.web.app.get_kanban_board")
+    def test_kanban_hides_voice_without_key(
+        self,
+        mock_board: MagicMock,
+        client: TestClient,
+    ) -> None:
+        """Kanban page should hide voice widget when OPENAI_API_KEY not set."""
+        mock_board.return_value = {}
+        with patch.dict("os.environ", {}, clear=True):
+            response = client.get("/kanban")
+        assert response.status_code == 200
+        assert "voice-widget-btn" not in response.text
+
+    @patch("agenttree.web.app._get_flow_issues")
+    def test_flow_passes_has_openai_key_true(
+        self,
+        mock_flow: MagicMock,
+        client: TestClient,
+    ) -> None:
+        """Flow page should pass has_openai_key=True when env var is set."""
+        mock_flow.return_value = []
+        with patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"}):
+            response = client.get("/flow")
+        assert response.status_code == 200
+        assert "voice-widget-btn" in response.text
+
+    @patch("agenttree.web.app._get_flow_issues")
+    def test_flow_hides_voice_without_key(
+        self,
+        mock_flow: MagicMock,
+        client: TestClient,
+    ) -> None:
+        """Flow page should hide voice widget when OPENAI_API_KEY not set."""
+        mock_flow.return_value = []
+        with patch.dict("os.environ", {}, clear=True):
+            response = client.get("/flow")
+        assert response.status_code == 200
+        assert "voice-widget-btn" not in response.text


### PR DESCRIPTION
## Summary

Implementation for **Issue #253**: Add persistent voice chat widget to web UI with URL-aware context and navigation

**Issue link:** [View in AgentTree Flow](http://localhost:8080/flow?issue=253)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)