### PR TITLE
[Issue 258] mypy hangs indefinitely in agent containers causing stalls

### DIFF
--- a/agenttree/templates/default.agenttree.yaml
+++ b/agenttree/templates/default.agenttree.yaml
@@ -179,7 +179,7 @@ flows:
               - run:
                   command: if [ -f "$(git rev-parse --show-toplevel)/scripts/mypy_changed.py" ]; then uv run python "$(git rev-parse --show-toplevel)/scripts/mypy_changed.py"; else uv run mypy {{PROJECT_NAME}}; fi || echo "mypy warnings (pre-existing)"
                   must_pass: true
-                  timeout: 900
+                  timeout: 180
               - section_check:
                   file: review.md
                   section: Self-Review Checklist

--- a/scripts/mypy_changed.py
+++ b/scripts/mypy_changed.py
@@ -39,12 +39,17 @@ def main() -> int:
         return 0
 
     print(f"Running mypy on {len(targets)} changed files.")
-    result = subprocess.run(
-        ["mypy", "--ignore-missing-imports", *targets],
-        cwd=repo_root,
-        check=False,
-    )
-    return result.returncode
+    try:
+        result = subprocess.run(
+            ["mypy", "--ignore-missing-imports", *targets],
+            cwd=repo_root,
+            check=False,
+            timeout=120,
+        )
+        return result.returncode
+    except subprocess.TimeoutExpired:
+        print("mypy timed out after 120 seconds; skipping (CI will catch errors)")
+        return 0
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_mypy_changed.py
+++ b/tests/unit/test_mypy_changed.py
@@ -1,0 +1,55 @@
+"""Tests for scripts/mypy_changed.py timeout handling."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from scripts.mypy_changed import main
+
+
+@patch("scripts.mypy_changed._changed_python_files")
+@patch("scripts.mypy_changed._repo_root")
+def test_main_timeout_returns_zero(
+    mock_root: MagicMock, mock_changed: MagicMock
+) -> None:
+    """When mypy times out, main() should return 0 and print a warning."""
+    mock_root.return_value = Path("/fake")
+    mock_changed.return_value = ["agenttree/foo.py"]
+
+    with patch("scripts.mypy_changed.subprocess.run") as mock_run:
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="mypy", timeout=120)
+        result = main()
+
+    assert result == 0
+
+
+@patch("scripts.mypy_changed._changed_python_files")
+@patch("scripts.mypy_changed._repo_root")
+def test_main_normal_completion(
+    mock_root: MagicMock, mock_changed: MagicMock
+) -> None:
+    """When mypy completes normally, main() returns its exit code."""
+    mock_root.return_value = Path("/fake")
+    mock_changed.return_value = ["agenttree/bar.py"]
+
+    with patch("scripts.mypy_changed.subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=1)
+        result = main()
+
+    assert result == 1
+
+
+@patch("scripts.mypy_changed._changed_python_files")
+@patch("scripts.mypy_changed._repo_root")
+def test_main_no_changed_files(
+    mock_root: MagicMock, mock_changed: MagicMock
+) -> None:
+    """When no files changed, main() should skip mypy and return 0."""
+    mock_root.return_value = Path("/fake")
+    mock_changed.return_value = []
+
+    result = main()
+
+    assert result == 0


### PR DESCRIPTION
## Summary

Implementation for **Issue #258**: mypy hangs indefinitely in agent containers causing stalls

**Issue link:** [View in AgentTree Flow](http://localhost:8080/flow?issue=258)

### Approach
Add a timeout to `mypy_changed.py` subprocess call and reduce the hook-level timeout in config files to prevent mypy hangs from stalling agents indefinitely. The script-level timeout (120s) catches hangs at the source, while the reduced hook timeout (180s) provides a safety net. On timeout, exit gracefully since CI catches real type errors....

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)