### PR TITLE
[Issue 0] Add full-system restart command and optional COO template

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,9 @@ agenttree start 42 --tool aider
 
 # Force restart (kills existing agent)
 agenttree start 42 --force
+
+# Restart the full AgentTree process (server + heartbeat + active agents)
+agenttree restart
 ```
 
 ### Monitor Agents

--- a/agenttree/cli/__init__.py
+++ b/agenttree/cli/__init__.py
@@ -38,6 +38,7 @@ from agenttree.cli.workflow import (
 )
 from agenttree.cli.agents import (
     start_issue,
+    restart,
     agents_status,
     attach,
     output,
@@ -49,6 +50,7 @@ from agenttree.cli.agents import (
 # Register all commands with main group
 main.add_command(start_all)
 main.add_command(start_issue)
+main.add_command(restart)
 main.add_command(server)
 main.add_command(run_command)
 main.add_command(agents_status)

--- a/agenttree/cli/agents.py
+++ b/agenttree/cli/agents.py
@@ -1,4 +1,4 @@
-"""Agent management commands (start, agents, sandbox, attach, send, output, stop, kill)."""
+"""Agent management commands (start, restart, attach, send, output, stop, kill)."""
 
 import shutil
 import subprocess
@@ -523,6 +523,71 @@ def output(issue_id: str, role: str, lines: int) -> None:
 
     output_text = capture_pane(agent.tmux_session, lines=lines)
     console.print(output_text)
+
+
+def _schedule_detached_command(command: list[str], *, delay_seconds: float = 0.0) -> None:
+    """Run a command in a detached process, optionally after a short delay."""
+    if delay_seconds > 0:
+        delayed_command = [
+            sys.executable,
+            "-c",
+            (
+                "import subprocess, time; "
+                f"time.sleep({delay_seconds!r}); "
+                f"subprocess.run({command!r}, check=False)"
+            ),
+        ]
+        subprocess.Popen(
+            delayed_command,
+            cwd=Path.cwd(),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        return
+
+    subprocess.Popen(
+        command,
+        cwd=Path.cwd(),
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+
+@click.command()
+@click.option("--host", default="0.0.0.0", help="Host to bind to when restarting the full system")
+@click.option("--port", default=None, type=int, help="Port to bind to when restarting the full system")
+def restart(
+    host: str,
+    port: int | None,
+) -> None:
+    """Restart the full AgentTree process safely.
+
+    This restarts the web server, heartbeat, manager, and active issue agents.
+    It is intended for config/code changes that require a full system reboot.
+    """
+    agenttree_executable = shutil.which("agenttree") or sys.argv[0]
+
+    try:
+        command = [agenttree_executable, "start"]
+        if host != "0.0.0.0":
+            command.extend(["--host", host])
+        if port is not None:
+            command.extend(["--port", str(port)])
+        _schedule_detached_command(command, delay_seconds=1.0)
+    except OSError as e:
+        console.print(f"[red]Error: Could not schedule restart: {e}[/red]")
+        sys.exit(1)
+
+    console.print("[green]✓ Scheduled full AgentTree restart[/green]")
+    console.print("[dim]A detached 'agenttree start' will relaunch the server, heartbeat, manager, and active agents.[/dim]")
+    from agenttree.cli.server import stop_all as stop_all_command
+
+    ctx = click.get_current_context()
+    ctx.invoke(stop_all_command)
 
 
 @click.command()

--- a/agenttree/cli/setup.py
+++ b/agenttree/cli/setup.py
@@ -297,6 +297,7 @@ def init(worktrees_dir: str | None, project: str | None) -> None:
         agents_repo.ensure_repo()
         console.print("[green]✓ _agenttree/ repository created[/green]")
         _ensure_optional_role_skill(repo_path, "architect")
+        _ensure_optional_role_skill(repo_path, "coo")
         _ensure_optional_role_skill(repo_path, "setup")
 
         # Always create knowledge base population issue

--- a/agenttree/templates/architect.md
+++ b/agenttree/templates/architect.md
@@ -45,7 +45,7 @@ When you receive a heartbeat ping (every 5 minutes), do this:
    - Reset or reimplement the issue:
      - `agenttree reset --issue <id> -y` for full reset
      - `agenttree reimplement --issue <id> -y` if only implementation failed
-   - Restart: `agenttree start <id>`
+   - Restart the issue: `agenttree start <id> --force`
 
 ### If an Issue Reaches a Review Stage
 
@@ -63,6 +63,7 @@ Give a quick review — make sure it's reasonable — but don't block on minor i
 | `agenttree reset --issue <id> -y` | Full reset — wipes everything, back to backlog |
 | `agenttree reimplement --issue <id> -y` | Reset to implement.setup, keeps plan files |
 | `agenttree start <id>` | Start an agent for an issue |
+| `agenttree restart` | Restart the full AgentTree system |
 | `agenttree stop <id>` | Stop an agent |
 | `agenttree approve <id>` | Approve at human review stage |
 | `agenttree approve <id> --skip-approval` | Approve without PR approval check |
@@ -115,3 +116,5 @@ Once your test issue flows through to `accepted`:
 - Never write implementation code for issues. Only fix agenttree infrastructure.
 - Be patient. Give the system time to work before intervening.
 - The goal is a system that works without you. Every fix should be permanent.
+- Use `agenttree start <id> --force` for issue-level restarts.
+- If you change server/heartbeat behavior or config that only loads at startup, use `agenttree restart` to restart the full system.

--- a/agenttree/templates/coo.md
+++ b/agenttree/templates/coo.md
@@ -1,0 +1,79 @@
+# COO Agent
+
+You are the **COO** of this AgentTree system. Your job is to keep the workflow healthy, spot repeated friction, and make careful operational improvements.
+
+You are not the product visionary. You are not the feature implementer. You are the operator who makes sure the right work keeps moving.
+
+## Core Responsibilities
+
+1. Monitor active issues and stalled agents.
+2. Nudge or restart agents when they are stuck.
+3. Read feedback and logs to spot repeated workflow friction.
+4. Make small, surgical improvements to skills, templates, config, or process.
+5. Record what you changed and whether it helped.
+
+## Operating Principles
+
+- Prefer small fixes over sweeping rewrites.
+- Do not react to a single bad run unless it is catastrophic.
+- Intervene when the same friction appears across 2+ issues, or when one issue is clearly dead.
+- Log operational reasoning so future cycles can see the pattern.
+
+## Restart Guidance
+
+Use the new restart command for full-system restarts. For issue-level restarts, keep using `agenttree start <id> --force`.
+
+### Hot-reloads automatically
+- `.agenttree.yaml` role and stage config
+- `_agenttree/skills/*.md`
+- `_agenttree/templates/*.md`
+- `_agenttree/knowledge/*.md`
+
+### Restart the affected agent when
+- container image or mount configuration changes
+- model changes should apply to an already-running role
+- the agent is stalled, dead, or wedged
+
+### Restart the full system when
+- server/heartbeat behavior changed
+- server host/port changed
+- startup-only process wiring changed
+
+### Commands
+
+```bash
+# Restart one issue agent
+agenttree start <id> --force
+
+# Restart a host role
+agenttree start coo --force
+
+# Restart the full AgentTree system
+agenttree restart
+```
+
+Do not tell a running host-level agent to `agenttree stop` the whole system and then `agenttree start` again. Once the stop lands, the caller is gone. Use `agenttree restart` for the whole system.
+
+## Monitoring Loop
+
+On each check-in:
+
+1. `agenttree status`
+2. `agenttree stalls`
+3. Read output only for suspicious issues: `agenttree output <id>`
+4. Check host roles when relevant: `agenttree output manager`, `agenttree output architect`, etc.
+5. Intervene only where there is actual friction
+
+## Allowed Changes
+
+You may improve:
+- `_agenttree/skills/*.md`
+- `_agenttree/templates/*.md`
+- `.agenttree.yaml`
+- `_agenttree/knowledge/*.md`
+
+When you change something:
+1. Make one change at a time.
+2. Log it.
+3. Watch the next few issues.
+4. Revert if it made things worse.

--- a/agenttree/templates/default.agenttree.yaml
+++ b/agenttree/templates/default.agenttree.yaml
@@ -67,6 +67,19 @@ roles:
   #     image: agenttree-host:latest
   #   skill: architect.md
 
+  # Optional: COO operations role (host-level, no container)
+  # Uncomment to enable an operational supervisor that watches stalls,
+  # understands what hot-reloads vs what needs a restart, and makes small
+  # system/process improvements over time.
+  # coo:
+  #   description: "Operational supervisor for system health and restarts"
+  #   tool: claude
+  #   model: sonnet
+  #   container:
+  #     enabled: false
+  #     image: agenttree-host:latest
+  #   skill: coo.md
+
 # Workflow flows
 # The default flow defines stages inline (dict). Secondary flows reference
 # stages by dot path (list). A bare stage name like "implement" expands to

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -2155,6 +2155,19 @@ class TestInitKnowledgeIssue:
         assert setup_skill.exists()
         assert "Setup Agent" in setup_skill.read_text()
 
+    def test_ensure_optional_role_skill_creates_coo_template(self, tmp_path):
+        """Should create coo.md in _agenttree/skills when missing."""
+        from agenttree.cli.setup import _ensure_optional_role_skill
+
+        skills_dir = tmp_path / "_agenttree" / "skills"
+        skills_dir.mkdir(parents=True)
+
+        _ensure_optional_role_skill(tmp_path, "coo")
+
+        coo_skill = skills_dir / "coo.md"
+        assert coo_skill.exists()
+        assert "COO Agent" in coo_skill.read_text()
+
     def test_prompt_notes_migration_shows_explanation(self, tmp_path, capsys):
         """Should display explanation about AgentTree notes manager."""
         from agenttree.cli.setup import _prompt_notes_migration

--- a/tests/unit/test_cli_agents.py
+++ b/tests/unit/test_cli_agents.py
@@ -185,3 +185,46 @@ class TestHostRoleCliCommands:
         mock_kill.assert_called_once_with("testproject-setup-000")
         assert result.exit_code == 0
         assert "Stopped setup" in result.output
+
+
+class TestRestartCommand:
+    """Tests for the restart command."""
+
+    def test_restart_without_issue_restarts_full_system(self, cli_runner):
+        """restart with no issue id should restart server, heartbeat, and agents."""
+        from agenttree.cli import main
+
+        mock_ctx = MagicMock()
+
+        with patch("agenttree.cli.agents.shutil.which", return_value="/usr/local/bin/agenttree"):
+            with patch("agenttree.cli.agents.subprocess.Popen") as mock_popen:
+                with patch("agenttree.cli.agents.click.get_current_context", return_value=mock_ctx):
+                    result = cli_runner.invoke(main, ["restart"])
+
+        mock_popen.assert_called_once()
+        args, kwargs = mock_popen.call_args
+        assert args[0][0].endswith("python") or "python" in args[0][0]
+        assert kwargs["start_new_session"] is True
+        mock_ctx.invoke.assert_called_once()
+        assert result.exit_code == 0
+        assert "Scheduled full AgentTree restart" in result.output
+
+    def test_restart_forwards_host_and_port(self, cli_runner):
+        """restart should pass custom host and port through to start."""
+        from agenttree.cli import main
+
+        mock_ctx = MagicMock()
+
+        with patch("agenttree.cli.agents.shutil.which", return_value="/usr/local/bin/agenttree"):
+            with patch("agenttree.cli.agents.subprocess.Popen") as mock_popen:
+                with patch("agenttree.cli.agents.click.get_current_context", return_value=mock_ctx):
+                    result = cli_runner.invoke(main, ["restart", "--host", "127.0.0.1", "--port", "9900"])
+
+        mock_popen.assert_called_once()
+        args, kwargs = mock_popen.call_args
+        script = args[0][2]
+        assert "127.0.0.1" in script
+        assert "9900" in script
+        assert kwargs["start_new_session"] is True
+        mock_ctx.invoke.assert_called_once()
+        assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- add a first-class `agenttree restart` command that safely restarts the full AgentTree process by scheduling a detached `agenttree start` before shutdown
- seed new repos with an optional `COO` role template and default-config comments that explain restart-aware operations and hot-reload vs restart boundaries
- update restart guidance in the Architect template and document that issue-level restarts should continue to use `agenttree start <id> --force`

## Test plan
- [x] `uv run pytest tests/unit/test_cli_agents.py -q`
- [x] `uv run pytest tests/unit/test_cli.py -q`
- [ ] `uv run python scripts/pr_preflight.py --base origin/main`
- [ ] CI passes

Preflight note: the full repo preflight currently fails in existing config-validation tests unrelated to this branch, reporting missing baseline skill/template files such as `plan/selfcheck.md`, `implement/debug.md`, `independent_review.md`, `address_independent.md`, `ui_review.md`, `knowledge_base.md`, and `ui_review.md` template wiring.

Made with [Cursor](https://cursor.com)